### PR TITLE
Fix lower bound for signed `generate_range` function

### DIFF
--- a/src/gen.rs
+++ b/src/gen.rs
@@ -49,7 +49,7 @@ macro_rules! range {
 			impl<Generator: Rng<OUTPUT>, const OUTPUT: usize> RandomRange<Generator, OUTPUT> for $signed {
 				fn random_range<Bounds: RangeBounds<Self>>(r: &mut Generator, bounds: Bounds) -> Self {
 					let lower = match bounds.start_bound() {
-						Bound::Included(lower) => *lower,
+						Bound::Included(lower) => lower.saturating_add(1),
 						Bound::Excluded(lower) => lower.saturating_add(1),
 						Bound::Unbounded => <$signed>::MIN
 					};

--- a/src/gen.rs
+++ b/src/gen.rs
@@ -161,6 +161,15 @@ mod tests {
 
 			let number = rng.generate_range(..-32);
 			assert!((..-32).contains(&number), "{} was outside of ..-32", number);
+
+			let number = rng.generate_range(1..3);
+			assert!((1..3).contains(&number), "{} was outside of 1..3", number);
+
+			let number = rng.generate_range(-3..3);
+			assert!((-3..3).contains(&number), "{} was outside of -3..3", number);
+
+			let number = rng.generate_range(-13..=-12);
+			assert!((-13..=-12).contains(&number), "{} was outside of -13..=-12", number);
 		}
 	}
 

--- a/src/gen.rs
+++ b/src/gen.rs
@@ -169,7 +169,11 @@ mod tests {
 			assert!((-3..3).contains(&number), "{} was outside of -3..3", number);
 
 			let number = rng.generate_range(-13..=-12);
-			assert!((-13..=-12).contains(&number), "{} was outside of -13..=-12", number);
+			assert!(
+				(-13..=-12).contains(&number),
+				"{} was outside of -13..=-12",
+				number
+			);
 		}
 	}
 


### PR DESCRIPTION
Hi! I took the liberty to go ahead and address [this issue](https://github.com/Absolucy/nanorand-rs/issues/35).
I'm not sure I understand fully the code, but this simple change fixes the issue.
I added some tests that were failing before I introduced the fix, to make sure the issue was real in the first place.
