### PR TITLE
Implement Fisher-Yates shuffle

### DIFF
--- a/src/rand.rs
+++ b/src/rand.rs
@@ -74,7 +74,7 @@ pub trait Rng<const OUTPUT: usize>: Clone {
 		let target = target.as_mut();
 		let target_len = target.len();
 		for idx in (1..target_len).rev() {
-			let random_idx = self.generate_range(0..idx+1);
+			let random_idx = self.generate_range(0..idx + 1);
 			target.swap(idx, random_idx);
 		}
 	}

--- a/src/rand.rs
+++ b/src/rand.rs
@@ -73,8 +73,8 @@ pub trait Rng<const OUTPUT: usize>: Clone {
 	{
 		let target = target.as_mut();
 		let target_len = target.len();
-		for idx in 0..target_len {
-			let random_idx = self.generate_range(0..target_len);
+		for idx in (1..target_len).rev() {
+			let random_idx = self.generate_range(0..idx+1);
 			target.swap(idx, random_idx);
 		}
 	}


### PR DESCRIPTION
Move from naive shuffle to Fisher-Yates shuffle as per https://github.com/Absolucy/nanorand-rs/issues/37

This implementation matches the expected distribution and removes bias: [99999, 100058, 100052, 100122, 100425, 99344]

Closes  https://github.com/Absolucy/nanorand-rs/issues/37