### PR TITLE
Fix SmallCrush 

### DIFF
--- a/.github/workflows/smallcrush.yml
+++ b/.github/workflows/smallcrush.yml
@@ -17,9 +17,9 @@ jobs:
         name: "Run SmallCrush"
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v3
             - name: Install TestU01 and Clang
-              run: sudo apt-get update && sudo apt-get install -y libtestu01-0-dev libtestu01-0-dev-common libtestu01-0 llvm-10 clang-10
+              run: sudo apt-get update && sudo apt-get install -y libtestu01-0-dev libtestu01-0-dev-common libtestu01-0 llvm-11 clang-11
             - name: "Install stable Rust toolchain"
               uses: actions-rs/toolchain@v1
               with:


### PR DESCRIPTION
This PR addresses the issue with SmallCrush failing to find clang and llvm. It also solves the deprecation warning about nodejs.