### PR TITLE
fix: underlying issue of generate_range of signed integers being off by 1

### DIFF
--- a/src/gen.rs
+++ b/src/gen.rs
@@ -49,7 +49,7 @@ macro_rules! range {
 			impl<Generator: Rng<OUTPUT>, const OUTPUT: usize> RandomRange<Generator, OUTPUT> for $signed {
 				fn random_range<Bounds: RangeBounds<Self>>(r: &mut Generator, bounds: Bounds) -> Self {
 					let lower = match bounds.start_bound() {
-						Bound::Included(lower) => lower.saturating_add(1),
+						Bound::Included(lower) => *lower,
 						Bound::Excluded(lower) => lower.saturating_add(1),
 						Bound::Unbounded => <$signed>::MIN
 					};
@@ -61,7 +61,7 @@ macro_rules! range {
 					assert!(upper >= lower, "{} >= {} (lower bound was bigger than upper bound)", upper, lower);
 					let lower = lower.wrapping_sub(<$signed>::MIN) as $type;
 					let upper = upper.wrapping_sub(<$signed>::MIN) as $type;
-					<$type>::random_range(r, lower..=upper).wrapping_add(<$signed>::MAX as $type) as $signed
+					<$type>::random_range(r, lower..=upper).wrapping_add(<$signed>::MIN as $type) as $signed
 				}
 			}
 		)+
@@ -147,6 +147,9 @@ mod tests {
 				"{} was outside of ..1024",
 				number
 			);
+
+			let number = rng.generate_range(0u64..1);
+			assert!((0u64..1).contains(&number), "{} was outside of 0..1", number);
 		}
 	}
 	#[test]
@@ -174,6 +177,9 @@ mod tests {
 				"{} was outside of -13..=-12",
 				number
 			);
+
+			let number = rng.generate_range(0..1);
+			assert!((0..1).contains(&number), "{} was outside of 0..1", number);
 		}
 	}
 


### PR DESCRIPTION
This fixes the underlying issue of [`WyRand::generate_range` being off by 1](https://github.com/Absolucy/nanorand-rs/issues/45).

While [this pull request](https://github.com/Absolucy/nanorand-rs/pull/38) allegedly was supposed to fix [this earlier version of the issue](https://github.com/Absolucy/nanorand-rs/issues/35), the underlying issue was not the `lower` bound on line 55 but rather the conversion from the unsigned to signed integer on line 64 being off by one. The [change on line 55](https://github.com/Absolucy/nanorand-rs/pull/38/files) introduced a new bug whereby `generate_range(0..1)` would be considered out of bounds.

I added new tests for `generate_range(0..1)` for signed as well as unsigned integer ranges.