### PR TITLE
Update getrandom to 0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,22 +21,21 @@ wyrand = []
 pcg64 = []
 chacha = []
 rdseed = ["std"]
-getrandom_custom = ["getrandom/custom"]
 
 [dependencies]
 zeroize = { version = "1.5", optional = true, features = ["zeroize_derive"] }
 
 # optional getrandom with 'js' feature for WASM
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-getrandom = { version = "0.2", optional = true, features = ["js"] }
+getrandom = { version = "0.3", optional = true, features = ["wasm_js"] }
 
 # optional getrandom with 'rdrand' feature for x86(-64)
 [target.'cfg(any(target_arch = "x86", target_arch = "x86_64"))'.dependencies]
-getrandom = { version = "0.2", optional = true, features = ["rdrand"] }
+getrandom = { version = "0.3", optional = true }
 
 # optional getrandom without any features for non-WASM, non-x86 targets.
 [target.'cfg(not(any(target_arch = "wasm32", target_arch = "x86", target_arch = "x86_64")))'.dependencies]
-getrandom = { version = "0.2", optional = true }
+getrandom = { version = "0.3", optional = true }
 
 [dev-dependencies]
 hex = "0.4.3"

--- a/src/entropy.rs
+++ b/src/entropy.rs
@@ -1,6 +1,3 @@
-#[cfg(feature = "getrandom_custom")]
-pub use getrandom::register_custom_getrandom;
-
 #[cfg(all(target_vendor = "apple", not(feature = "getrandom")))]
 pub use darwin::entropy as system;
 #[cfg(all(
@@ -42,7 +39,7 @@ pub mod openbsd;
 /// Pull in system entropy using the [`getrandom`](https://crates.io/crates/getrandom) crate.
 /// Uses backup entropy (rdseed and system time) if it fails.
 pub fn system(out: &mut [u8]) {
-	match getrandom::getrandom(out) {
+	match getrandom::fill(out) {
 		Ok(_) => (),
 		Err(_) => backup(out),
 	}


### PR DESCRIPTION
Get random changed a lot of its internals in 0.3. Now backend if a cargo feature that downstream consumers have to set instead of library choosing for them. I tried preserving the intent behind the existing configs while upgrading to 0.3.